### PR TITLE
Allow cuebreakpoints to parse cue files that contain unicode

### DIFF
--- a/src/lib/cue_scan.l
+++ b/src/lib/cue_scan.l
@@ -18,6 +18,20 @@ int cue_lineno = 1;
 ws		[ \t\r]
 nonws		[^ \t\r\n]
 
+
+ASC     [\x00-\x7f]
+ASCN    [\x00-\b]
+ASCNN   [\v-\x1f]
+ASCNNN  [\x21-\x7f]
+U       [\x80-\xbf]
+U2      [\xc2-\xdf]
+U3      [\xe0-\xef]
+U4      [\xf0-\xf4]
+
+UANY    {ASC}|{U2}{U}|{U3}{U}{U}|{U4}{U}{U}{U}
+UANYN   {ASCN}|{ASCNN}|{ASCNNN}|{U2}{U}|{U3}{U}{U}|{U4}{U}{U}{U}
+UWS     {ws}|{U2}{U}|{U3}{U}{U}|{U4}{U}{U}{U}
+
 %option noyywrap
 %option prefix="cue_yy"
 
@@ -32,7 +46,7 @@ nonws		[^ \t\r\n]
 		return STRING;
 		}
 
-<NAME>{nonws}+	{
+<NAME>{UANYN}+	{
 		yylval.sval = strdup(yytext);
 		BEGIN(INITIAL);
 		return STRING;
@@ -84,7 +98,7 @@ SIZE_INFO	{ BEGIN(NAME); yylval.ival = PTI_SIZE_INFO;  return SIZE_INFO; }
 
 ISRC		{ BEGIN(NAME); return TRACK_ISRC; }
 
-^{ws}*REM.*\n	{ cue_lineno++; /* ignore comments */ }
+^{UWS}*REM.*\n	{ cue_lineno++; /* ignore comments */ }
 {ws}+		{ /* ignore whitespace */ }
 
 [[:digit:]]+	{ yylval.ival = atoi(yytext); return NUMBER; }


### PR DESCRIPTION
The attached patch makes the lexxer not barf at unicode.  cuebreakpoints works for me now. I haven't tried the other tools~
