### PR TITLE
Rewrite configure.ac

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1,15 +1,10 @@
-# configure.ac - process with autoconf to create configure script
-
-AC_INIT(cuetools,1.4.0-dev,svend@ciffer.net)
-# getting conflicting errors about config.h.in
-AC_CONFIG_HEADERS(config.h)
-AM_INIT_AUTOMAKE($PACKAGE_NAME,$PACKAGE_VERSION)
-
+AC_INIT([cuetools], [1.4.0-dev], [svend@ciffer.net])
+AM_INIT_AUTOMAKE([-Wall -Werror foreign])
+AC_PROG_CC
 AC_PROG_INSTALL
 AC_PROG_RANLIB
-AC_PROG_CC
 AM_PROG_LEX
 AC_PROG_YACC
-
+AC_CONFIG_HEADERS([config.h])
 AC_CONFIG_FILES([Makefile doc/Makefile src/Makefile src/lib/Makefile src/tools/Makefile extras/Makefile])
 AC_OUTPUT


### PR DESCRIPTION
Use example from automake manual:

AC_INIT([amhello], [1.0], [bug-automake@gnu.org])
AM_INIT_AUTOMAKE([-Wall -Werror foreign])
AC_PROG_CC
AC_CONFIG_HEADERS([config.h])
AC_CONFIG_FILES([
 Makefile
 src/Makefile
])
AC_OUTPUT
