### PR TITLE
suppress extra-portability warnings that make autoreconf fail

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1,5 +1,5 @@
 AC_INIT([cuetools], [1.4.0], [svend@ciffer.net])
-AM_INIT_AUTOMAKE([-Wall -Werror foreign])
+AM_INIT_AUTOMAKE([-Wall -Werror -Wno-extra-portability foreign])
 AC_PROG_CC
 AC_PROG_INSTALL
 AC_PROG_RANLIB


### PR DESCRIPTION
I've tried to use `autoreconf` with this package on quite a few systems, and it would always fail. This option is required to compile this package, maybe because the default behaviour of `-Wall` changed in `autoconf 1.12`. Tested and working on OS X and Debian.
