### PR TITLE
Trimming double quotes from fields to prevent them appearing in output

### DIFF
--- a/src/lib/cdtext.c
+++ b/src/lib/cdtext.c
@@ -92,6 +92,10 @@ char *cdtext_get(int pti, Cdtext *cdtext)
 {
 	for (; PTI_END != cdtext->pti; cdtext++) {
 		if (pti == cdtext->pti) {
+			if (NULL != cdtext->value && '"' == cdtext->value[0] && '"' == cdtext->value[strlen(cdtext->value) - 1]) { /* Remove surrounding double quotes to prevent them appearing in fields */
+				cdtext->value++;
+				cdtext->value[strlen(cdtext->value) - 1] = 0;
+			}
 			return cdtext->value;
 		}
 	}


### PR DESCRIPTION
Most cue files have string without spaces enclosed in doublequotes like this:

    TRACK <nr> AUDIO
      TITLE "<TITLE>"
      PERFORMER "<ARTIST>"
      INDEX 01 43:15:45

This would lead cueprint (also cueprint) to output those quotes, making the artist `"<ARTIST>"`..

`cdtext_get` now checks for this case and removes the quotes if necessary