### PR TITLE
added support for linux on power

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,6 @@
 language: c
+arch:
+  - ppc64le
+  - amd64
 install: autoreconf --install
 script: ./configure && make


### PR DESCRIPTION
Hi,
I had added ppc64le(Linux on Power) support on travis-ci in the branch and looks like its been successfully added. I believe it is ready for the final review and merge. The travis ci build logs can be verified from the link below.

https://travis-ci.com/github/ujjwalsh/cuetools/builds/185051204

Please have a look.

Regards,
ujjwal