### PR TITLE
change/update cuetag.sh syntax

### DIFF
--- a/src/tools/cuetag.sh
+++ b/src/tools/cuetag.sh
@@ -1,59 +1,56 @@
-#! /bin/sh
+#!/bin/sh
 
 # cuetag.sh - tag files based on cue/toc file information
 # uses cueprint output
 # usage: cuetag.sh <cuefile|tocfile> [file]...
 
 CUEPRINT=cueprint
-cue_file=""
+cue_file=''
+
+# makes text lowercase ; simplifies file format check syntax
+lowercase(){ echo "$*" | tr '[:upper:]' '[:lower:]';}
 
 # print usage instructions
 usage()
 {
-	echo "usage: cuetag.sh <cuefile|tocfile> [file]..."
+	echo 'usage: cuetag.sh <cuefile|tocfile> [file]...'
 	echo
-	echo "cuetag.sh adds tags to files based on cue or toc information"
+	echo 'cuetag.sh adds tags to files based on cue or toc information'
 	echo
-	echo "Supported formats (format extension, format name, tagging utility):"
-	echo "ogg, Ogg Vorbis, vorbiscomment"
-	echo "flac, FLAC, metaflac"
-	echo "mp3, MP3, mp3info"
-	echo "txt, Vorbis Comment Text File, tee"
+	echo 'Supported formats (format extension, format name, tagging utility):'
+	echo 'ogg, Ogg Vorbis, vorbiscomment'
+	echo 'flac, FLAC, metaflac'
+	echo 'mp3, MP3, mp3info'
+	echo 'txt, Vorbis Comment Text File, tee'
 	echo
-	echo "cuetag.sh uses cueprint, which must be in your path"
+	echo 'cuetag.sh uses cueprint, which must be in your path'
 }
 
 # Vorbis Comments
 # for FLAC and Ogg Vorbis files
 vorbis()
 {
-	trackno=$1; shift
+	trackno="$1"; shift
 	file="$1"; shift
-	fields="$@"
+	fields="$*"
 
-	# FLAC tagging
-	#  --remove-all-tags overwrites existing comments
-	METAFLAC="metaflac --remove-all-tags --import-tags-from=-"
-
-	# Ogg Vorbis tagging
-	# -w overwrites existing comments
-	# -a appends to existing comments
-	VORBISCOMMENT="vorbiscomment -w -c -"
-
-	# VC text file format
-	# TODO: this also outputs to stdout
-	TXTFILE="tee"
-
-	case "$file" in
-	*.[Ff][Ll][Aa][Cc])
-		VORBISTAG=$METAFLAC
-		;;
-	*.[Oo][Gg][Gg])
-		VORBISTAG=$VORBISCOMMENT
-		;;
-	*.[Tt][Xx][Tt])
-		VORBISTAG=$TXTFILE
-		;;
+	case "$(lowercase "$file")" in
+		*.flac)
+			# FLAC tagging
+			#  --remove-all-tags overwrites existing comments
+			VORBISTAG='metaflac --remove-all-tags --import-tags-from=-'
+			;;
+		*.ogg)
+			# Ogg Vorbis tagging
+			# -w overwrites existing comments
+			# -a appends to existing comments
+			VORBISTAG='vorbiscomment -w -c -'
+			;;
+		*.txt)
+			# VC text file format
+			# TODO: this also outputs to stdout
+			VORBISTAG='tee'
+			;;
 	esac
 
 	# space separated list of recommended standard field names
@@ -84,36 +81,36 @@ vorbis()
 	ISRC='%i %u'
 
 	(for field in $fields; do
-		 case "$field" in
-		 (*=*) echo "$field";;
-		 (*)
-			 value=""
-			 for conv in $(eval echo \$$field); do
-				 value=$($CUEPRINT -n $trackno -t "$conv\n" "$cue_file")
-
-				 if [ -n "$value" ]; then
-					 echo "$field=$value"
-					 break
-				 fi
-			 done
-			 ;;
-		 esac
+		case "$field" in
+			(*=*) echo "$field";;
+			(*)
+				value=''
+				for conv in $(eval echo \$"$field"); do
+					value=$($CUEPRINT -n "$trackno" -t "$conv\n" "$cue_file")
+					if [ -n "$value" ]; then
+						echo "$field=$value"
+						break
+					fi
+				done
+				;;
+		esac
 	 done) | $VORBISTAG "$file"
 }
 
 id3()
 {
-	MP3TAG=$(which mid3v2) \
-		|| MP3TAG=$(which id3v2)
+	for mp3_cmd in mid3v2 id3v2; do
+		type "$mp3_cmd" >/dev/null 2>&1 && MP3TAG="$mp3_cmd" && break
+	done
 	if [ -z "${MP3TAG}" ]; then
 		echo "error: not found '(m)id3v2'."
 		exit 1
 	fi
 
 	# space separated list of ID3 v1.1 tags
-	# see http://id3lib.sourceforge.net/id3/idev1.html
+	# see http://id3lib.sourceforge.net/id3/id3v1.html
 
-	fields="TITLE ALBUM ARTIST YEAR COMMENT GENRE TRACKNUMBER"
+	fields='TITLE ALBUM ARTIST YEAR COMMENT GENRE TRACKNUMBER'
 
 	# fields' corresponding cueprint conversion characters
 	# separate alternates with a space
@@ -128,42 +125,42 @@ id3()
 
 	for field in $fields; do
 		case "$field" in
-		*=*) value="${field#*=}";;
-		*)
-			value=""
-			for conv in $(eval echo \$$field); do
-				value=$($CUEPRINT -n $1 -t "$conv\n" "$cue_file")
+			*=*) value="${field#*=}";;
+			*)
+				value=''
+				for conv in $(eval echo \$"$field"); do
+					value=$($CUEPRINT -n "$1" -t "$conv\n" "$cue_file")
 
-				if [ -n "$value" ]; then
-					break
-				fi
-			done
-			;;
+					if [ -n "$value" ]; then
+						break
+					fi
+				done
+				;;
 		esac
 
 		if [ -n "$value" ]; then
 			case $field in
-			TITLE)
-				$MP3TAG -t "$value" "$2"
-				;;
-			ALBUM)
-				$MP3TAG -A "$value" "$2"
-				;;
-			ARTIST)
-				$MP3TAG -a "$value" "$2"
-				;;
-			YEAR)
-				$MP3TAG -y "$value" "$2"
-				;;
-			COMMENT)
-				$MP3TAG -c "$value" "$2"
-				;;
-			GENRE)
-				$MP3TAG -g "$value" "$2"
-				;;
-			TRACKNUMBER)
-				$MP3TAG -T "$value" "$2"
-				;;
+				TITLE)
+					$MP3TAG -t "$value" "$2"
+					;;
+				ALBUM)
+					$MP3TAG -A "$value" "$2"
+					;;
+				ARTIST)
+					$MP3TAG -a "$value" "$2"
+					;;
+				YEAR)
+					$MP3TAG -y "$value" "$2"
+					;;
+				COMMENT)
+					$MP3TAG -c "$value" "$2"
+					;;
+				GENRE)
+					$MP3TAG -g "$value" "$2"
+					;;
+				TRACKNUMBER)
+					$MP3TAG -T "$value" "$2"
+					;;
 			esac
 		fi
 	done
@@ -185,34 +182,31 @@ main()
 	NUM_FILES=0 FIELDS=
 	for arg in "$@"; do
 		case "$arg" in
-		*.*) NUM_FILES=$(expr $NUM_FILES + 1);;
-		*) FIELDS="$FIELDS $arg";;
+			*.*) NUM_FILES=$(( NUM_FILES + 1));;
+			*) FIELDS="$FIELDS $arg";;
 		esac
 	done
 
-	if [ $NUM_FILES -ne $ntrack ]; then
-		echo "warning: number of files does not match number of tracks"
+	if [ "$NUM_FILES" -ne "$ntrack" ]; then
+		echo 'warning: number of files does not match number of tracks'
 	fi
 
 	for file in "$@"; do
-		case $file in
-		*.[Ff][Ll][Aa][Cc])
-			vorbis $trackno "$file" $FIELDS
-			;;
-		*.[Oo][Gg][Gg])
-			vorbis $trackno "$file" $FIELDS
-			;;
-		*.[Mm][Pp]3)
-			id3 $trackno "$file" $FIELDS
-			;;
-		*.[Tt][Xx][Tt])
-			vorbis $trackno "$file"
-			;;
-		*.*)
-			echo "$file: uknown file type"
-			;;
+		case "$(lowercase "$file")" in
+			*.flac|*.ogg)
+				vorbis $trackno "$file" $FIELDS
+				;;
+			*.mp3)
+				id3 $trackno "$file" $FIELDS
+				;;
+			*.txt)
+				vorbis $trackno "$file"
+				;;
+			*.*)
+				echo "$file: uknown file type"
+				;;
 		esac
-		trackno=$(($trackno + 1))
+		trackno=$((trackno + 1))
 	done
 }
 


### PR DESCRIPTION
1) changed quoting on variables according to recommendations from 'shellcheck' utility
2) simplified checks for file type by adding lowercase() function
3) changed expr math to use "$(())"
4) changed check for existence of mid3v2/id3v2 to use the 'type' command instead of 'which'
type is a shell-builtin, so it is preferable to using the external 'which' command
5) corrected ID3 tag url typo (
6) minor formatting (changing tabbing in 'case' commands for consistency
7) changed double-quotes ("") to single quotes where variables were not referenced

Also removed the METAFLAC, VORBISCOMMENT, and TXTFILE variables by placing their contents in the VORBISTAG variable directly along with the comments explaining each of the options used

Thank you for the hard work. :)